### PR TITLE
fix cache-control response header honoring for browser cache endpoint and `immutable` honoring for Pro CDN

### DIFF
--- a/assets/rulesTemplate.json
+++ b/assets/rulesTemplate.json
@@ -184,6 +184,12 @@
           }
         },
         {
+          "name": "downstreamCache",
+          "options": {
+            "behavior": "TUNNEL_ORIGIN"
+          }
+        },
+        {
           "name": "allowTransferEncoding",
           "options": {
             "enabled": true
@@ -434,6 +440,12 @@
             "honorSMaxage": true,
             "revalidationSettings": "",
             "honorProxyRevalidate": true
+          }
+        },
+        {
+          "name": "downstreamCache",
+          "options": {
+            "behavior": "TUNNEL_ORIGIN"
           }
         }
       ],


### PR DESCRIPTION
Bug: There is a problem with the browser cache endpoint's response. The `Cache-Control` header is not propagated as-is to the browser. It should be `Cache-Control: max-age=31534000, immutable, private` but it is `Cache-Control: max-age=0, no-cache, no-store`, and also the response has `Pragma: no-cache` which shouldn't have.

The solution has two steps:

- Use "caching" behavior on the browser cache endpoint rule, just like Pro CDN. This fixes the problem with `Pragma` header. This also fixes the problem with `max-age` and `private`, but `immutable` flag is still missing.
- Use "downstreamCache" behavior in the browser cache endpoint rule. This fixes the problem with `immutable` flag. Add this behavior also to the ProCDN rule since it may be needed in the future.