### PR TITLE
ci: fix type error when running scripts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "resolveJsonModule": true
   },
   "ts-node": {
-    "esm": true,
     "experimentalSpecifierResolution": "node"
   },
   "include": ["**/*.ts"],


### PR DESCRIPTION
Fixes recent problems with node `18.19.0`, like [this one](https://github.com/fingerprintjs/fingerprint-pro-akamai-proxy-integration/actions/runs/7161856699/job/19498040730).

Note: Switching to node20 didn't help.