### PR TITLE
fix: error on regexp for ingress endpoint query parameters

### DIFF
--- a/assets/rulesTemplate.json
+++ b/assets/rulesTemplate.json
@@ -345,7 +345,7 @@
             "behavior": "REGEX_REPLACE",
             "matchMultiple": false,
             "keepQueryString": true,
-            "matchRegex": "\\/__integration_path__\\/__result_path__",
+            "matchRegex": "\\/__integration_path__\\/__result_path__(?:\\/[^\\/?]+)*\\/?(?:\\?.*)?$",
             "targetRegex": "/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}"
           }
         },

--- a/assets/rulesTemplate.json
+++ b/assets/rulesTemplate.json
@@ -345,7 +345,7 @@
             "behavior": "REGEX_REPLACE",
             "matchMultiple": false,
             "keepQueryString": true,
-            "matchRegex": "\\/__integration_path__\\/__result_path__(?:\\/[^\\/?]+)*\\/?(?:\\?.*)?$",
+            "matchRegex": "\\/__integration_path__\\/__result_path__(.*)",
             "targetRegex": "/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}"
           }
         },


### PR DESCRIPTION
This fixes the problem about duplication of query parameters to be replaced.

Tested this regular expression with these values:
```
/__integration_path__/__result_path__/hello/world?query=123
/__integration_path__/__result_path__/?query=123
/__integration_path__/__result_path__?query=123
/__integration_path__/__result_path__
/__integration_path__/__result_path__/hello
/__integration_path__/__result_path__/hello/world
/__integration_path__/__result_path__/hello?query=123
/__integration_path__/__result_path__/hello/world/?query=123
```

Result was:

```
/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}
/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}
/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}
/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}
/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}
/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}
/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}
/?ii=fingerprint-pro-akamai/{{user.PMUSER_FPJS_INTEGRATION_VERSION}}/ingress&{{builtin.AK_QUERY}}
```