### PR TITLE
(INTER-1895) Fix Supernet error

### DIFF
--- a/assets/rulesTemplate.json
+++ b/assets/rulesTemplate.json
@@ -145,7 +145,7 @@
             "cacheKeyHostname": "ORIGIN_HOSTNAME",
             "compress": true,
             "enableTrueClientIp": false,
-            "verificationMode": "THIRD_PARTY",
+            "verificationMode": "CUSTOM",
             "originSni": true,
             "httpPort": 80,
             "httpsPort": 443,
@@ -153,7 +153,16 @@
             "originCertificate": "",
             "ports": "",
             "ipVersion": "DUALSTACK",
-            "minTlsVersion": "DYNAMIC"
+            "minTlsVersion": "DYNAMIC",
+            "customValidCnValues": [
+              "{{Origin Hostname}}",
+              "{{Forward Host Header}}"
+            ],
+            "originCertsToHonor": "STANDARD_CERTIFICATE_AUTHORITIES",
+            "standardCertificateAuthorities": [
+              "akamai-permissive",
+              "THIRD_PARTY_AMAZON"
+            ]
           }
         },
         {
@@ -339,7 +348,7 @@
             "cacheKeyHostname": "ORIGIN_HOSTNAME",
             "compress": true,
             "enableTrueClientIp": true,
-            "verificationMode": "THIRD_PARTY",
+            "verificationMode": "CUSTOM",
             "originSni": true,
             "httpPort": 80,
             "httpsPort": 443,
@@ -349,7 +358,16 @@
             "ipVersion": "DUALSTACK",
             "trueClientIpHeader": "FPJS-Proxy-Client-IP",
             "trueClientIpClientSetting": false,
-            "minTlsVersion": "DYNAMIC"
+            "minTlsVersion": "DYNAMIC",
+            "customValidCnValues": [
+              "{{Origin Hostname}}",
+              "{{Forward Host Header}}"
+            ],
+            "originCertsToHonor": "STANDARD_CERTIFICATE_AUTHORITIES",
+            "standardCertificateAuthorities": [
+              "akamai-permissive",
+              "THIRD_PARTY_AMAZON"
+            ]
           }
         },
         {
@@ -415,7 +433,7 @@
             "cacheKeyHostname": "ORIGIN_HOSTNAME",
             "compress": true,
             "enableTrueClientIp": false,
-            "verificationMode": "THIRD_PARTY",
+            "verificationMode": "CUSTOM",
             "originSni": true,
             "httpPort": 80,
             "httpsPort": 443,
@@ -423,7 +441,16 @@
             "originCertificate": "",
             "ports": "",
             "minTlsVersion": "DYNAMIC",
-            "ipVersion": "DUALSTACK"
+            "ipVersion": "DUALSTACK",
+            "customValidCnValues": [
+              "{{Origin Hostname}}",
+              "{{Forward Host Header}}"
+            ],
+            "originCertsToHonor": "STANDARD_CERTIFICATE_AUTHORITIES",
+            "standardCertificateAuthorities": [
+              "akamai-permissive",
+              "THIRD_PARTY_AMAZON"
+            ]
           }
         },
         {

--- a/scripts/deployRules.ts
+++ b/scripts/deployRules.ts
@@ -32,6 +32,43 @@ const createNewVersion = async (propertyId: string) => {
   return getLatestVersion(propertyId)
 }
 
+const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
+    akamaiRequest({
+        path: `/papi/v1/properties/${propertyId}/versions/${version}/rules?contractId=${process.env.AK_CONTRACT_ID}&groupId=${process.env.AK_GROUP_ID}`,
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json-patch+json',
+        },
+        body: JSON.stringify([
+            {
+                op: 'replace',
+                path: '/rules/children/0/behaviors/0/options/customValidCnValues',
+                value: [
+                    "{{Forward Host Header}}",
+                    "{{Origin Hostname}}"
+                ]
+            },
+            {
+                op: 'replace',
+                path: '/rules/children/0/behaviors/0/options/verificationMode',
+                value: "CUSTOM"
+            },
+            {
+                op: 'replace',
+                path: '/rules/children/0/behaviors/0/options/originCertsToHonor',
+                value: "STANDARD_CERTIFICATE_AUTHORITIES"
+            },
+            {
+                op: 'replace',
+                path: '/rules/children/0/behaviors/0/options/standardCertificateAuthorities',
+                value: [
+                    "THIRD_PARTY_AMAZON",
+                    "akamai-permissive"
+                ]
+            }
+        ])
+    })
+
 const patchOriginHostname = async (propertyId: string, version: string) =>
   akamaiRequest({
     path: `/papi/v1/properties/${propertyId}/versions/${version}/rules?contractId=${process.env.AK_CONTRACT_ID}&groupId=${process.env.AK_GROUP_ID}`,
@@ -130,6 +167,7 @@ import('../dist/patch-body/body.json').then((module) => {
       } catch (_) {
         // Ignore error if fingerprint rules not exists
       }
+      await patchDefaultRuleOrigin(propertyId, propertyVersion)
       await patchAddFingerprintRules(propertyId, propertyVersion, JSON.stringify(patchReqBody))
       await activateVersion(propertyId, propertyVersion)
     } catch (e: any) {

--- a/scripts/deployRules.ts
+++ b/scripts/deployRules.ts
@@ -42,7 +42,7 @@ const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
         body: JSON.stringify([
             {
                 op: 'replace',
-                path: '/rules/children/0/behaviors/0/options/customValidCnValues',
+                path: '/rules/behaviors/0/options/customValidCnValues',
                 value: [
                     "{{Forward Host Header}}",
                     "{{Origin Hostname}}"
@@ -50,17 +50,17 @@ const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
             },
             {
                 op: 'replace',
-                path: '/rules/children/0/behaviors/0/options/verificationMode',
+                path: '/rules/behaviors/0/options/verificationMode',
                 value: "CUSTOM"
             },
             {
                 op: 'replace',
-                path: '/rules/children/0/behaviors/0/options/originCertsToHonor',
+                path: '/rules/behaviors/0/options/originCertsToHonor',
                 value: "STANDARD_CERTIFICATE_AUTHORITIES"
             },
             {
                 op: 'replace',
-                path: '/rules/children/0/behaviors/0/options/standardCertificateAuthorities',
+                path: '/rules/behaviors/0/options/standardCertificateAuthorities',
                 value: [
                     "THIRD_PARTY_AMAZON",
                     "akamai-permissive"


### PR DESCRIPTION
This pull request updates the Akamai property rules configuration to enhance origin certificate validation and control. The main changes involve switching the verification mode from `THIRD_PARTY` to `CUSTOM`, specifying custom valid certificate CN values, and defining which certificate authorities should be honored. These updates are reflected both in the `rulesTemplate.json` and in the deployment script logic.

Certificate validation improvements:

* Changed `verificationMode` from `THIRD_PARTY` to `CUSTOM` and added `customValidCnValues`, `originCertsToHonor`, and `standardCertificateAuthorities` options in multiple rule entries within `assets/rulesTemplate.json`. This allows for more granular control over which certificates are accepted and which certificate authorities are trusted. [[1]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L148-R165) [[2]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L342-R351) [[3]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L352-R370) [[4]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L418-R453)

Deployment script enhancements:

* Added the `patchDefaultRuleOrigin` function in `scripts/deployRules.ts` to automate updating the default rule origin certificate validation settings during deployment, ensuring consistency with the new configuration.
* Integrated `patchDefaultRuleOrigin` into the deployment workflow in `scripts/deployRules.ts`, so these certificate validation updates are applied whenever rules are deployed.