### PR TITLE
INTER-1895 Fix SSL Mismatch

### DIFF
--- a/assets/rulesTemplate.json
+++ b/assets/rulesTemplate.json
@@ -145,7 +145,7 @@
             "cacheKeyHostname": "ORIGIN_HOSTNAME",
             "compress": true,
             "enableTrueClientIp": false,
-            "verificationMode": "THIRD_PARTY",
+            "verificationMode": "CUSTOM",
             "originSni": true,
             "httpPort": 80,
             "httpsPort": 443,
@@ -153,7 +153,16 @@
             "originCertificate": "",
             "ports": "",
             "ipVersion": "DUALSTACK",
-            "minTlsVersion": "DYNAMIC"
+            "minTlsVersion": "DYNAMIC",
+            "customValidCnValues": [
+              "{{Origin Hostname}}",
+              "{{Forward Host Header}}"
+            ],
+            "originCertsToHonor": "STANDARD_CERTIFICATE_AUTHORITIES",
+            "standardCertificateAuthorities": [
+              "akamai-permissive",
+              "THIRD_PARTY_AMAZON"
+            ]
           }
         },
         {
@@ -339,7 +348,7 @@
             "cacheKeyHostname": "ORIGIN_HOSTNAME",
             "compress": true,
             "enableTrueClientIp": true,
-            "verificationMode": "THIRD_PARTY",
+            "verificationMode": "CUSTOM",
             "originSni": true,
             "httpPort": 80,
             "httpsPort": 443,
@@ -349,7 +358,16 @@
             "ipVersion": "DUALSTACK",
             "trueClientIpHeader": "FPJS-Proxy-Client-IP",
             "trueClientIpClientSetting": false,
-            "minTlsVersion": "DYNAMIC"
+            "minTlsVersion": "DYNAMIC",
+            "customValidCnValues": [
+              "{{Origin Hostname}}",
+              "{{Forward Host Header}}"
+            ],
+            "originCertsToHonor": "STANDARD_CERTIFICATE_AUTHORITIES",
+            "standardCertificateAuthorities": [
+              "akamai-permissive",
+              "THIRD_PARTY_AMAZON"
+            ]
           }
         },
         {
@@ -415,7 +433,7 @@
             "cacheKeyHostname": "ORIGIN_HOSTNAME",
             "compress": true,
             "enableTrueClientIp": false,
-            "verificationMode": "THIRD_PARTY",
+            "verificationMode": "CUSTOM",
             "originSni": true,
             "httpPort": 80,
             "httpsPort": 443,
@@ -423,7 +441,16 @@
             "originCertificate": "",
             "ports": "",
             "minTlsVersion": "DYNAMIC",
-            "ipVersion": "DUALSTACK"
+            "ipVersion": "DUALSTACK",
+            "customValidCnValues": [
+              "{{Origin Hostname}}",
+              "{{Forward Host Header}}"
+            ],
+            "originCertsToHonor": "STANDARD_CERTIFICATE_AUTHORITIES",
+            "standardCertificateAuthorities": [
+              "akamai-permissive",
+              "THIRD_PARTY_AMAZON"
+            ]
           }
         },
         {

--- a/scripts/deployRules.ts
+++ b/scripts/deployRules.ts
@@ -32,6 +32,43 @@ const createNewVersion = async (propertyId: string) => {
   return getLatestVersion(propertyId)
 }
 
+const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
+    akamaiRequest({
+        path: `/papi/v1/properties/${propertyId}/versions/${version}/rules?contractId=${process.env.AK_CONTRACT_ID}&groupId=${process.env.AK_GROUP_ID}`,
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json-patch+json',
+        },
+        body: JSON.stringify([
+            {
+                op: 'replace',
+                path: '/rules/children/0/behaviors/0/options/customValidCnValues',
+                value: [
+                    "{{Forward Host Header}}",
+                    "{{Origin Hostname}}"
+                ]
+            },
+            {
+                op: 'replace',
+                path: '/rules/children/0/behaviors/0/options/verificationMode',
+                value: "CUSTOM"
+            },
+            {
+                op: 'replace',
+                path: '/rules/children/0/behaviors/0/options/originCertsToHonor',
+                value: "STANDARD_CERTIFICATE_AUTHORITIES"
+            },
+            {
+                op: 'replace',
+                path: '/rules/children/0/behaviors/0/options/standardCertificateAuthorities',
+                value: [
+                    "THIRD_PARTY_AMAZON",
+                    "akamai-permissive"
+                ]
+            }
+        ])
+    })
+
 const patchOriginHostname = async (propertyId: string, version: string) =>
   akamaiRequest({
     path: `/papi/v1/properties/${propertyId}/versions/${version}/rules?contractId=${process.env.AK_CONTRACT_ID}&groupId=${process.env.AK_GROUP_ID}`,
@@ -130,6 +167,7 @@ import('../dist/patch-body/body.json').then((module) => {
       } catch (_) {
         // Ignore error if fingerprint rules not exists
       }
+      await patchDefaultRuleOrigin(propertyId, propertyVersion)
       await patchAddFingerprintRules(propertyId, propertyVersion, JSON.stringify(patchReqBody))
       await activateVersion(propertyId, propertyVersion)
     } catch (e: any) {

--- a/scripts/deployRules.ts
+++ b/scripts/deployRules.ts
@@ -41,7 +41,7 @@ const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
         },
         body: JSON.stringify([
             {
-                op: 'replace',
+                op: 'add',
                 path: '/rules/behaviors/0/options/customValidCnValues',
                 value: [
                     "{{Forward Host Header}}",
@@ -54,12 +54,12 @@ const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
                 value: "CUSTOM"
             },
             {
-                op: 'replace',
+                op: 'add',
                 path: '/rules/behaviors/0/options/originCertsToHonor',
                 value: "STANDARD_CERTIFICATE_AUTHORITIES"
             },
             {
-                op: 'replace',
+                op: 'add',
                 path: '/rules/behaviors/0/options/standardCertificateAuthorities',
                 value: [
                     "THIRD_PARTY_AMAZON",

--- a/scripts/deployRules.ts
+++ b/scripts/deployRules.ts
@@ -65,6 +65,10 @@ const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
                     "THIRD_PARTY_AMAZON",
                     "akamai-permissive"
                 ]
+            },
+            {
+                op: 'remove',
+                path: '/rules/behaviors/1',
             }
         ])
     })

--- a/scripts/deployRules.ts
+++ b/scripts/deployRules.ts
@@ -42,7 +42,7 @@ const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
         body: JSON.stringify([
             {
                 op: 'replace',
-                path: '/rules/children/0/behaviors/0/options/customValidCnValues',
+                path: '/rules/behaviors/0/options/customValidCnValues',
                 value: [
                     "{{Forward Host Header}}",
                     "{{Origin Hostname}}"
@@ -50,17 +50,17 @@ const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
             },
             {
                 op: 'replace',
-                path: '/rules/children/0/behaviors/0/options/verificationMode',
+                path: '/rules/behaviors/0/options/verificationMode',
                 value: "CUSTOM"
             },
             {
                 op: 'replace',
-                path: '/rules/children/0/behaviors/0/options/originCertsToHonor',
+                path: '/rules/behaviors/0/options/originCertsToHonor',
                 value: "STANDARD_CERTIFICATE_AUTHORITIES"
             },
             {
                 op: 'replace',
-                path: '/rules/children/0/behaviors/0/options/standardCertificateAuthorities',
+                path: '/rules/behaviors/0/options/standardCertificateAuthorities',
                 value: [
                     "THIRD_PARTY_AMAZON",
                     "akamai-permissive"


### PR DESCRIPTION
This pull request introduces significant enhancements to the Akamai property rules configuration by switching origin certificate verification to a custom mode and specifying which certificate authorities and common name values should be honored. Additionally, a new script function is added to automate patching these settings during deployment. These changes improve security and flexibility in certificate validation for origin connections.

**Akamai property rules configuration updates:**

* Changed `verificationMode` from `"THIRD_PARTY"` to `"CUSTOM"` in multiple origin rules, enabling custom certificate validation logic. [[1]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L148-R165) [[2]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L342-R351) [[3]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L418-R453)
* Added `customValidCnValues`, `originCertsToHonor`, and `standardCertificateAuthorities` options to origin rules, specifying which common names and certificate authorities are considered valid. [[1]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L148-R165) [[2]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L352-R370) [[3]](diffhunk://#diff-0e04646a4fac66496892addd365e4f060c8ec555229e5532b756e28d99cb2b91L418-R453)

**Deployment script enhancements:**

* Introduced `patchDefaultRuleOrigin` function in `scripts/deployRules.ts` to automate patching the default rule with custom certificate validation settings, including removing an unnecessary behavior.
* Updated deployment flow to call `patchDefaultRuleOrigin` before adding fingerprint rules and activating the version, ensuring the new settings are applied during deployment.