### PR TITLE
chore: linter fix on deploy-rules ci

### DIFF
--- a/scripts/deployRules.ts
+++ b/scripts/deployRules.ts
@@ -33,45 +33,39 @@ const createNewVersion = async (propertyId: string) => {
 }
 
 const patchDefaultRuleOrigin = async (propertyId: string, version: string) =>
-    akamaiRequest({
-        path: `/papi/v1/properties/${propertyId}/versions/${version}/rules?contractId=${process.env.AK_CONTRACT_ID}&groupId=${process.env.AK_GROUP_ID}`,
-        method: 'PATCH',
-        headers: {
-            'Content-Type': 'application/json-patch+json',
-        },
-        body: JSON.stringify([
-            {
-                op: 'add',
-                path: '/rules/behaviors/0/options/customValidCnValues',
-                value: [
-                    "{{Forward Host Header}}",
-                    "{{Origin Hostname}}"
-                ]
-            },
-            {
-                op: 'replace',
-                path: '/rules/behaviors/0/options/verificationMode',
-                value: "CUSTOM"
-            },
-            {
-                op: 'add',
-                path: '/rules/behaviors/0/options/originCertsToHonor',
-                value: "STANDARD_CERTIFICATE_AUTHORITIES"
-            },
-            {
-                op: 'add',
-                path: '/rules/behaviors/0/options/standardCertificateAuthorities',
-                value: [
-                    "THIRD_PARTY_AMAZON",
-                    "akamai-permissive"
-                ]
-            },
-            {
-                op: 'remove',
-                path: '/rules/behaviors/1',
-            }
-        ])
-    })
+  akamaiRequest({
+    path: `/papi/v1/properties/${propertyId}/versions/${version}/rules?contractId=${process.env.AK_CONTRACT_ID}&groupId=${process.env.AK_GROUP_ID}`,
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json-patch+json',
+    },
+    body: JSON.stringify([
+      {
+        op: 'add',
+        path: '/rules/behaviors/0/options/customValidCnValues',
+        value: ['{{Forward Host Header}}', '{{Origin Hostname}}'],
+      },
+      {
+        op: 'replace',
+        path: '/rules/behaviors/0/options/verificationMode',
+        value: 'CUSTOM',
+      },
+      {
+        op: 'add',
+        path: '/rules/behaviors/0/options/originCertsToHonor',
+        value: 'STANDARD_CERTIFICATE_AUTHORITIES',
+      },
+      {
+        op: 'add',
+        path: '/rules/behaviors/0/options/standardCertificateAuthorities',
+        value: ['THIRD_PARTY_AMAZON', 'akamai-permissive'],
+      },
+      {
+        op: 'remove',
+        path: '/rules/behaviors/1',
+      },
+    ]),
+  })
 
 const patchOriginHostname = async (propertyId: string, version: string) =>
   akamaiRequest({


### PR DESCRIPTION
This pull request makes minor formatting improvements to the `patchDefaultRuleOrigin` function in `scripts/deployRules.ts`, ensuring consistent use of single quotes and array formatting for object property values. No functional logic was changed.