### PR TITLE
INTER-1986: Add region handler rule and region variable

### DIFF
--- a/.changeset/olive-donuts-appear.md
+++ b/.changeset/olive-donuts-appear.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-akamai-proxy-integration': patch
+---
+
+Improved internal request routing logic for region.

--- a/assets/rulesTemplate.json
+++ b/assets/rulesTemplate.json
@@ -2,21 +2,17 @@
   "name": "Fingerprint",
   "children": [
     {
-      "name": "Ingress Endpoint Parser",
+      "name": "Region Handler",
       "children": [],
       "behaviors": [
         {
           "name": "setVariable",
           "options": {
             "valueSource": "EXTRACT",
-            "transform": "SUBSTITUTE",
-            "variableName": "PMUSER_FPJS_INGRESS_ENDPOINT",
+            "transform": "NONE",
+            "variableName": "PMUSER_FP_REGION",
             "extractLocation": "QUERY_STRING",
-            "queryParameterName": "region",
-            "regex": "^(\\w+)$",
-            "replacement": "$0.__ingress_url__",
-            "caseSensitive": false,
-            "globalSubstitution": true
+            "queryParameterName": "region"
           }
         }
       ],
@@ -24,17 +20,54 @@
         {
           "name": "queryStringParameter",
           "options": {
-            "matchOperator": "IS_ONE_OF",
+            "matchOperator": "EXISTS",
             "matchWildcardName": false,
             "matchCaseSensitiveName": true,
-            "parameterName": "region",
-            "values": [
-              "eu",
-              "ap"
-            ],
+            "parameterName": "region"
+          }
+        },
+        {
+          "name": "queryStringParameter",
+          "options": {
+            "matchOperator": "IS_NOT_ONE_OF",
+            "matchWildcardName": false,
+            "matchCaseSensitiveName": true,
             "matchWildcardValue": false,
             "matchCaseSensitiveValue": true,
-            "escapeValue": false
+            "escapeValue": false,
+            "parameterName": "region",
+            "values": [
+              "us"
+            ]
+          }
+        }
+      ],
+      "criteriaMustSatisfy": "all",
+      "comments": ""
+    },
+    {
+      "name": "Ingress Endpoint Parser",
+      "children": [],
+      "behaviors": [
+        {
+          "name": "setVariable",
+          "options": {
+            "valueSource": "EXPRESSION",
+            "transform": "NONE",
+            "variableName": "PMUSER_FPJS_INGRESS_ENDPOINT",
+            "variableValue": "{{user.PMUSER_FP_REGION}}.__ingress_url__"
+          }
+        }
+      ],
+      "criteria": [
+        {
+          "name": "matchVariable",
+          "options": {
+            "matchOperator": "IS_NOT",
+            "matchWildcardName": false,
+            "matchCaseSensitiveName": true,
+            "variableName": "PMUSER_FP_REGION",
+            "variableExpression": "us"
           }
         }
       ],

--- a/assets/rulesTemplate.json
+++ b/assets/rulesTemplate.json
@@ -29,7 +29,7 @@
         {
           "name": "queryStringParameter",
           "options": {
-            "matchOperator": "IS_NOT_ONE_OF",
+            "matchOperator": "IS_ONE_OF",
             "matchWildcardName": false,
             "matchCaseSensitiveName": true,
             "matchWildcardValue": false,
@@ -37,7 +37,8 @@
             "escapeValue": false,
             "parameterName": "region",
             "values": [
-              "us"
+              "eu",
+              "ap"
             ]
           }
         }

--- a/assets/variables.json
+++ b/assets/variables.json
@@ -54,5 +54,12 @@
     "description": "Generated via Fingerprint Dashboard",
     "hidden": false,
     "sensitive": true
+  },
+  {
+    "name": "PMUSER_FP_REGION",
+    "value": "us",
+    "description": "Points to region used for request routing",
+    "hidden": false,
+    "sensitive": false
   }
 ]


### PR DESCRIPTION
Add `Region Handler` rule that extracts the `region` query parameter into `PMUSER_FP_REGION` variable.