### PR TITLE
INTER-2023: CI add Akamai domain TXT record validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,14 @@ jobs:
           AK_CONTRACT_ID: '${{secrets.AK_CONTRACT_ID}}'
           FPJS_CI_DOMAIN: '${{secrets.FPJS_CI_DOMAIN}}'
         run: pnpm ts-node scripts/createProperty.ts
+      - name: Create Cloudflare TXT Record for Domain Validation
+        if: steps.create-akamai-property.outputs.HOSTNAME_VALIDATION_TOKEN != ''
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/dns_records'
+          method: 'POST'
+          customHeaders: '{"Authorization": "Bearer ${{ secrets.CF_AUTH_TOKEN }}"}'
+          data: '{"content": "${{steps.create-akamai-property.outputs.HOSTNAME_VALIDATION_TOKEN}}", "name": "${{steps.create-akamai-property.outputs.TXT_RECORD_HOST}}.${{steps.extract-branch.outputs.SUBDOMAIN}}.${{secrets.FPJS_CI_DOMAIN}}", "proxied": false, "type": "TXT", "comment": "Akamai domain validation for ${{steps.extract-branch.outputs.SUBDOMAIN}}", "ttl": 3600, "tags": ["owner:akamai-integration-ci"]}'
       - name: Build Patch Body
         run: pnpm build --type patchBody --proxy-secret '${{secrets.FPJS_PROXY_SECRET}}' --integration-path ${{secrets.INTEGRATION_PATH}} --agent-path ${{secrets.AGENT_PATH}} --result-path ${{secrets.RESULT_PATH}}
       - name: Deploy Akamai Rules
@@ -146,6 +154,14 @@ jobs:
           AK_CONTRACT_ID: '${{secrets.AK_CONTRACT_ID}}'
           FPJS_CI_DOMAIN: '${{secrets.FPJS_CI_DOMAIN}}'
         run: pnpm ts-node scripts/createProperty.ts
+      - name: Create Cloudflare TXT Record for Domain Validation
+        if: steps.create-akamai-property.outputs.HOSTNAME_VALIDATION_TOKEN != ''
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/dns_records'
+          method: 'POST'
+          customHeaders: '{"Authorization": "Bearer ${{ secrets.CF_AUTH_TOKEN }}"}'
+          data: '{"content": "${{steps.create-akamai-property.outputs.HOSTNAME_VALIDATION_TOKEN}}", "name": "${{steps.create-akamai-property.outputs.TXT_RECORD_HOST}}.${{steps.extract-branch.outputs.SUBDOMAIN}}.${{secrets.FPJS_CI_DOMAIN}}", "proxied": false, "type": "TXT", "comment": "Akamai domain validation for ${{steps.extract-branch.outputs.SUBDOMAIN}}", "ttl": 3600, "tags": ["owner:akamai-integration-ci"]}'
       - name: Build Patch Body
         run: pnpm build --type patchBody --proxy-secret secret --integration-path ${{secrets.INTEGRATION_PATH}} --agent-path ${{secrets.AGENT_PATH}} --result-path ${{secrets.RESULT_PATH}} --ingress-url ${{secrets.MOCK_FPCDN}}
       - name: Deploy Akamai Rules

--- a/scripts/createProperty.ts
+++ b/scripts/createProperty.ts
@@ -1,3 +1,4 @@
+import { appendFile } from 'fs/promises'
 import { akamaiRequest } from './utils/akamaiRequest'
 import { getProperty } from './utils/getProperty'
 import { CI_DOMAIN } from './utils/constants'
@@ -94,7 +95,11 @@ const findEdgeHostname = async () => {
 }
 
 const patchEdgeHostname = async (propertyId: string) => {
-  await akamaiRequest({
+  const {
+    body: {
+      hostnames: { items: hostnames },
+    },
+  } = await akamaiRequest({
     path: `/papi/v1/properties/${propertyId}/versions/1/hostnames`,
     method: 'PATCH',
     body: JSON.stringify({
@@ -107,6 +112,26 @@ const patchEdgeHostname = async (propertyId: string) => {
       ],
     }),
   })
+
+  const hostname = hostnames.find((h) => h.cnameFrom === CI_DOMAIN)
+  return hostname?.domainOwnershipVerification?.validationTxt
+}
+
+const outputValidationTxt = async (validationTxt: { hostname: string; challengeToken: string }) => {
+  const txtRecord = `${validationTxt.hostname}. TXT ${validationTxt.challengeToken}`
+  const txtRecordHost = validationTxt.hostname.replace(`.${CI_DOMAIN}`, '')
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(
+      process.env.GITHUB_OUTPUT,
+      `TXT_RECORD=${txtRecord}\nTXT_RECORD_HOST=${txtRecordHost}\nHOSTNAME_VALIDATION_TOKEN=${validationTxt.challengeToken}\n`
+    )
+  } else {
+    console.log('=== Domain Ownership Verification ===')
+    console.log(`Host:  ${validationTxt.hostname}`)
+    console.log(`Type:  TXT`)
+    console.log(`Value: ${txtRecord}`)
+    console.log('=====================================')
+  }
 }
 
 const patchDefaultRuleOrigin = async (propertyId: string) =>
@@ -155,7 +180,10 @@ const handler = async () => {
     if (!hostname) {
       await createEdgeHostname()
     }
-    await patchEdgeHostname(propertyId)
+    const validationTxt = await patchEdgeHostname(propertyId)
+    if (validationTxt) {
+      await outputValidationTxt(validationTxt)
+    }
     const cpcodeId = await createCPCode()
     await patchCpcode(propertyId, cpcodeId)
     await patchDefaultRuleOrigin(propertyId)


### PR DESCRIPTION
Extract the domain ownership verification token from the `patchEdgeHostname` response and output it. Add a CI step to automatically create the TXT DNS record.