### PR TITLE
feat: add nested integration path support

### DIFF
--- a/.changeset/brave-snails-spend.md
+++ b/.changeset/brave-snails-spend.md
@@ -1,0 +1,5 @@
+---
+'fingerprint-pro-akamai-proxy-integration': minor
+---
+
+Add nested integration path support

--- a/assets/example.tf
+++ b/assets/example.tf
@@ -58,7 +58,7 @@ locals {
   fpjs_integration_path = var.fpjs_integration_path != "" ? var.fpjs_integration_path : random_string.fpjs_integration_path.result
   fpjs_agent_path = var.fpjs_agent_path != "" ? var.fpjs_agent_path : random_string.fpjs_agent_path.result
   fpjs_result_path = var.fpjs_result_path != "" ? var.fpjs_result_path : random_string.fpjs_result_path.result
-  fpjs_integration_path_escaped = replace(var.fpjs_integration_path, "/", "\\\\/")
+  fpjs_integration_path_escaped = replace(replace(var.fpjs_integration_path, "/", "\\\\/"), ".", "\\.")
 }
 
 data "akamai_property_rules_template" "rules" {

--- a/assets/example.tf
+++ b/assets/example.tf
@@ -25,7 +25,7 @@ resource "random_string" "fpjs_result_path" {
 variable "fpjs_integration_path" {
   type = string
   validation {
-    condition = can(regex("(^$|^[a-zA-Z0-9-]+$)", var.fpjs_integration_path))
+    condition = can(regex("(^$|^[a-zA-Z0-9/-]+$)", var.fpjs_integration_path))
     error_message = "Variable value must be a valid URL path"
   }
 }
@@ -58,6 +58,7 @@ locals {
   fpjs_integration_path = var.fpjs_integration_path != "" ? var.fpjs_integration_path : random_string.fpjs_integration_path.result
   fpjs_agent_path = var.fpjs_agent_path != "" ? var.fpjs_agent_path : random_string.fpjs_agent_path.result
   fpjs_result_path = var.fpjs_result_path != "" ? var.fpjs_result_path : random_string.fpjs_result_path.result
+  fpjs_integration_path_escaped = replace(var.fpjs_integration_path, "/", "\\\\/")
 }
 
 data "akamai_property_rules_template" "rules" {
@@ -65,6 +66,11 @@ data "akamai_property_rules_template" "rules" {
   variables {
     name  = "fpjs_integration_path"
     value = local.fpjs_integration_path
+    type = "string"
+  }
+  variables {
+    name = "fpjs_integration_path_escaped"
+    value = local.fpjs_integration_path_escaped
     type = "string"
   }
   variables {

--- a/assets/rulesTemplate.json
+++ b/assets/rulesTemplate.json
@@ -94,7 +94,7 @@
             "behavior": "REGEX_REPLACE",
             "matchMultiple": false,
             "keepQueryString": true,
-            "matchRegex": "\\/__integration_path__[\\/]?(.*)",
+            "matchRegex": "\\/__integration_path_escaped__[\\/]?(.*)",
             "targetRegex": "/$1"
           }
         }
@@ -525,7 +525,7 @@
                 "behavior": "REGEX_REPLACE",
                 "matchMultiple": false,
                 "keepQueryString": true,
-                "matchRegex": "\\/__integration_path__\\/__result_path__(.*)",
+                "matchRegex": "\\/__integration_path_escaped__\\/__result_path__(.*)",
                 "targetRegex": "$1"
               }
             }

--- a/generators/generatePatchBody.ts
+++ b/generators/generatePatchBody.ts
@@ -28,6 +28,7 @@ export default function generatePatchBody({
 
   let bodyString = JSON.stringify(body, null, 2)
   bodyString = bodyString.replace(/__integration_path__/g, integrationPath)
+  bodyString = bodyString.replace(/__integration_path_escaped__/g, integrationPath?.replace('/', '\\\\/'))
   bodyString = bodyString.replace(/__agent_path__/g, agentPath)
   bodyString = bodyString.replace(/__result_path__/g, resultPath)
   bodyString = bodyString.replace(/__proxy_secret__/g, proxySecret)

--- a/generators/generatePatchBody.ts
+++ b/generators/generatePatchBody.ts
@@ -28,7 +28,10 @@ export default function generatePatchBody({
 
   let bodyString = JSON.stringify(body, null, 2)
   bodyString = bodyString.replace(/__integration_path__/g, integrationPath)
-  bodyString = bodyString.replace(/__integration_path_escaped__/g, integrationPath?.replace('/', '\\\\/'))
+  bodyString = bodyString.replace(
+    /__integration_path_escaped__/g,
+    integrationPath?.replace('/', '\\\\/')?.replace('.', '\\.')
+  )
   bodyString = bodyString.replace(/__agent_path__/g, agentPath)
   bodyString = bodyString.replace(/__result_path__/g, resultPath)
   bodyString = bodyString.replace(/__proxy_secret__/g, proxySecret)

--- a/generators/generateTerraformPropertyRules.ts
+++ b/generators/generateTerraformPropertyRules.ts
@@ -10,6 +10,7 @@ export default function generateTerraformPropertyRules(options: TerraformOptions
   const [rulesBody, variablesBody] = [rulesTemplate, variablesTemplate].map((file) => {
     let bodyString = JSON.stringify(file, null, 2)
     bodyString = bodyString.replace(/__integration_path__/g, '${env.fpjs_integration_path}')
+    bodyString = bodyString.replace(/__integration_path_escaped__/g, '${env.fpjs_integration_path_escaped}')
     bodyString = bodyString.replace(/__agent_path__/g, '${env.fpjs_agent_path}')
     bodyString = bodyString.replace(/__result_path__/g, '${env.fpjs_result_path}')
     bodyString = bodyString.replace(/__proxy_secret__/g, '${env.fpjs_proxy_secret}')


### PR DESCRIPTION
This PR Solves INTER-1980

It provides new variable called for both patch body and terraform for escaping slashes with back slashes to adapt regex patterns and its called `integration_path_escaped`